### PR TITLE
Add bitcoin price ticker to header.

### DIFF
--- a/config.php
+++ b/config.php
@@ -5,3 +5,5 @@ defined( 'WP_DEFAULT_THEME' ) or define( 'WP_DEFAULT_THEME', 'btcsumo' );
 
 // Set the feed cache lifetime to 6 hours for development.
 define( 'BTCSUMO_FEED_CACHE_LIFETIME', 6 * HOUR_IN_SECONDS );
+
+define( 'DISABLE_WP_CRON', true );

--- a/themes/btcsumo/assets/scripts/main.js
+++ b/themes/btcsumo/assets/scripts/main.js
@@ -106,12 +106,32 @@
     } // load()
   };
 
+  /**
+   * Bitcoin price ticker related.
+   * @type {Object}
+   * @todo Add AJAX call to update prices periodically.
+   */
+  var BTCTicker = {
+    load: function() {
+      $( '#bitcoin-ticker-list li' ).click(function( e ) {
+        e.preventDefault();
+        var $this = $( this );
+        var info = $.parseJSON( $this.attr( 'data-info' ) );
+        $this.siblings().removeClass( 'active' );
+        $this.addClass( 'active' );
+
+        $( '#bitcoin-ticker-price' ).html( '<span>' + info.cur + '</span>' + info.price );
+      });
+    } // load()
+  };
+
   // Use this variable to set up the common and page specific functions. If you
   // rename this variable, you will also need to rename the namespace below.
   var Sage = {
     // All pages
     'common': {
       init: function() {
+        BTCTicker.load();
         // JavaScript to be fired on all pages
       },
       finalize: function() {

--- a/themes/btcsumo/assets/styles/layouts/_header.scss
+++ b/themes/btcsumo/assets/styles/layouts/_header.scss
@@ -29,4 +29,22 @@
       position: absolute;
     }
   }
+
+  #bitcoin-ticker {
+    float: right;
+
+    #bitcoin-ticker-list li {
+      cursor: pointer;
+    }
+
+    #bitcoin-ticker-price {
+      font-size: 2em;
+      font-weight: bold;
+
+      span {
+        font-size: .6em;
+        margin-right: 4px;
+      }
+    }
+  }
 }

--- a/themes/btcsumo/bower.json
+++ b/themes/btcsumo/bower.json
@@ -17,7 +17,8 @@
     "bootstrap-sass-official": {
       "main": [
         "./assets/stylesheets/_bootstrap.scss",
-        "./assets/javascripts/bootstrap/collapse.js"
+        "./assets/javascripts/bootstrap/collapse.js",
+        "./assets/javascripts/bootstrap/dropdown.js"
       ]
     }
   }

--- a/themes/btcsumo/functions.php
+++ b/themes/btcsumo/functions.php
@@ -21,6 +21,7 @@ $sage_includes = [
   'lib/wp-bs-navwalker.php',       // WordPress bootstrap nav walker
   'lib/custom-post-types.php',     // Custom Post Types registration
   'lib/custom-fields.php',         // Custom Fields for all post types
+  'lib/bitcoin-ticker.php',        // Bitcoin price ticker
   'lib/feeds.php'                  // Get the requested feed items
 ];
 

--- a/themes/btcsumo/lib/bitcoin-ticker.php
+++ b/themes/btcsumo/lib/bitcoin-ticker.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace BTCSumo\BitcoinTicker;
+
+// Schedule to update the bitcoin prices every 5 minutes.
+add_action( 'update_bitcoin_tickers', __NAMESPACE__ . '\\update_bitcoin_tickers' );
+if ( ! wp_next_scheduled( 'update_bitcoin_tickers' ) ) {
+  wp_schedule_event( time(), '5min', 'update_bitcoin_tickers' );
+}
+// If we ever need to clear the schedule, we can just call "wp_clear_scheduled_hook( 'update_bitcoin_tickers' );" here.
+
+/**
+ * Update the bitcoin tickers by fetching the current price using each ticker's API.
+ * @return array List of updated tickers.
+ */
+function update_bitcoin_tickers() {
+  $tickers = [
+    (object) [ 'id' => 'btce',     'name' => 'BTC-e',     'cur' => '$',   'url' => 'https://btc-e.com/api/3/ticker/btc_usd',
+      'cb' => function( $data ) { return $data->btc_usd->last; } ], // https://btc-e.com/api/3/docs#ticker
+    (object) [ 'id' => 'btcchina', 'name' => 'BTC China', 'cur' => '¥',   'url' => 'https://data.btcchina.com/data/ticker?market=btccny',
+      'cb' => function( $data ) { return $data->ticker->last; } ], // http://btcchina.org/api-market-data-documentation-en
+    (object) [ 'id' => 'bitfinex', 'name' => 'Bitfinex',  'cur' => '$',   'url' => 'https://api.bitfinex.com/v1/pubticker/BTCUSD',
+      'cb' => function( $data ) { return $data->last_price; } ], // https://www.bitfinex.com/pages/api
+    (object) [ 'id' => 'bitstamp', 'name' => 'Bitstamp',  'cur' => '$',   'url' => 'https://www.bitstamp.net/api/ticker_hour/',
+      'cb' => function( $data ) { return $data->last; } ], // https://www.bitstamp.net/api/
+    (object) [ 'id' => 'cavirtex', 'name' => 'CAVIRTEX',  'cur' => 'CAD', 'url' => 'https://cavirtex.com/api2/ticker.json?currencypair=BTCCAD',
+      'cb' => function( $data ) { return $data->ticker->BTCCAD->last; } ], // https://www.cavirtex.com/api_information#ticker_api
+    (object) [ 'id' => 'coinbase', 'name' => 'Coinbase',  'cur' => '$',   'url' => 'https://coinbase.com/api/v1/prices/spot_rate',
+      'cb' => function( $data ) { return $data->amount; } ], // https://developers.coinbase.com/api/v1#get-the-spot-price-of-bitcoin
+    (object) [ 'id' => 'itbit',    'name' => 'itBit',     'cur' => '$',   'url' => 'https://api.itbit.com/v1/markets/XBTUSD/ticker',
+      'cb' => function( $data ) { return $data->lastPrice; } ], // https://api.itbit.com/docs#market-data-get-ticker
+    (object) [ 'id' => 'lakebtc',  'name' => 'LakeBTC',   'cur' => '$',   'url' => 'https://www.lakebtc.com/api_v1/ticker',
+      'cb' => function( $data ) { return $data->USD->last; } ], // https://www.lakebtc.com/s/api
+    (object) [ 'id' => 'kraken',   'name' => 'Kraken',    'cur' => '$',   'url' => 'https://api.kraken.com/0/public/Ticker?pair=XXBTZUSD',
+      'cb' => function( $data ) { return $data->result->XXBTZUSD->c[0]; } ], // https://www.kraken.com/en-us/help/api#get-ticker-info
+    (object) [ 'id' => 'okcoin',   'name' => 'OKCoin',    'cur' => '$',   'url' => 'https://www.okcoin.com/api/v1/ticker.do?symbol=btc_usd',
+      'cb' => function( $data ) { return $data->ticker->last; } ] // https://www.okcoin.com/about/rest_api.do
+  ];
+
+  foreach ( $tickers as $ticker ) {
+    if ( $data = json_decode( get_curl_data( $ticker->url ) ) ) {
+      $ticker->price = number_format( call_user_func( $ticker->cb, $data ), 2 );
+      unset( $ticker->cb );
+    }
+  }
+
+  // Save the ticker data.
+  update_option( 'bitcoin_tickers', $tickers );
+
+  // Save the time of each update to know if the cron is working well, keep only the latest 10.
+  $btu = get_option( 'bitcoin_tickers_updated', [] );
+  array_unshift( $btu, date( 'YmdHis' ) );
+  update_option( 'bitcoin_tickers_updated', array_slice( $btu, 0, 10 ) );
+
+  return $tickers;
+}
+
+/**
+ * Get the list of bitcoin tickers.
+ * @return array List of bitcoin tickers.
+ */
+function get_bitcoin_tickers() {
+  if ( $tickers = get_option( 'bitcoin_tickers' ) ) {
+    return $tickers;
+  }
+  return update_bitcoin_tickers();
+}
+
+/**
+ * AJAX call to get the list of bitcoin tickers.
+ */
+function ajax_get_bitcoin_tickers() {
+  wp_send_json_success( get_bitcoin_tickers() );
+}
+add_action( 'wp_ajax_ajax_get_bitcoin_tickers', __NAMESPACE__ . '\\ajax_get_bitcoin_tickers' );
+add_action( 'wp_ajax_nopriv_ajax_get_bitcoin_tickers', __NAMESPACE__ . '\\ajax_get_bitcoin_tickers' );
+
+/**
+ * Get URL data via CURL.
+ * @param  string $url URL to load.
+ * @return string      Loaded content.
+ */
+function get_curl_data( $url ) {
+  $ch = curl_init( $url );
+
+  curl_setopt( $ch, CURLOPT_FAILONERROR,    true );
+  curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, false );
+  curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+  curl_setopt( $ch, CURLOPT_SSL_VERIFYHOST, false );
+  curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false );
+  curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT, 10 );
+
+  $data = curl_exec( $ch );
+  curl_close( $ch );
+  return $data;
+}
+
+?>

--- a/themes/btcsumo/lib/extras.php
+++ b/themes/btcsumo/lib/extras.php
@@ -43,3 +43,17 @@ function ajaxurl() {
   <?php
 }
 add_action('wp_head', __NAMESPACE__ . '\\ajaxurl');
+
+
+/**
+ * Add extra WP Cron schedules.
+ * @param array $schedules WP Cron schedules.
+ */
+function add_wpcron_schedules( $schedules ) {
+  $schedules['5min'] = [
+    'interval' => 5 * MINUTE_IN_SECONDS,
+    'display'  => __( 'Every 5 Minutes', 'btcsumo' )
+  ];
+  return $schedules;
+}
+add_filter( 'cron_schedules', __NAMESPACE__ . '\\add_wpcron_schedules' );

--- a/themes/btcsumo/templates/header.php
+++ b/themes/btcsumo/templates/header.php
@@ -2,6 +2,7 @@
   // This file assumes that you have included the nav walker from https://github.com/twittem/wp-bootstrap-navwalker
   // somewhere in your theme.
   use Roots\Sage\Assets;
+  use BTCSumo\BitcoinTicker;
 ?>
 
 <header class="banner navbar navbar-default navbar-static-top" role="banner">
@@ -22,5 +23,35 @@
       endif;
       ?>
     </nav>
+
+    <div id="bitcoin-ticker" class="btn-group hidden-xs">
+    <?php
+    if ( $tickers = BitcoinTicker\get_bitcoin_tickers() ) {
+      $ul = '<ul id="bitcoin-ticker-list" class="dropdown-menu dropdown-menu-right">';
+      $active_ticker = 'bitstamp';
+      foreach( $tickers as $ticker ) {
+        if ( $active_ticker === $ticker->id ) {
+          ?>
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="sr-only"><?= __( 'Toggle bitcoin prices', 'btcsumo' ); ?></span>
+            <span id="bitcoin-ticker-price"><span><?= $ticker->cur; ?></span><?= $ticker->price; ?></span> <span class="caret"></span>
+          </button>
+          <?php
+        }
+        // Unset any info we don't need.
+        unset( $ticker->url );
+
+        $ul .= sprintf( '<li data-info="%3$s"%2$s><a>%1$s</a>',
+          $ticker->name,
+          ( $active_ticker === $ticker->id ) ? ' class="active"' : '',
+          esc_attr( json_encode( $ticker ) )
+        );
+      }
+      $ul .= '</ul>';
+      echo $ul;
+    }
+    ?>
+    </div>
+
   </div>
 </header>


### PR DESCRIPTION
The prices are updated every 5 minutes with WP Cron, which gets triggered by an external unix cron job.
Currently, the mobile version doesn't display any price, since the header needs some redesigning to make it fit nicely.
The websites from which the prices are loaded are currently hardcoded, would be great to find a way to add them as options in WP Admin.
